### PR TITLE
fix: convert --zip を bool フラグ化し input に ZIP パスを直接指定可能にする

### DIFF
--- a/src/notebooklm_connector/cli.py
+++ b/src/notebooklm_connector/cli.py
@@ -60,7 +60,9 @@ def _build_parser() -> argparse.ArgumentParser:
     convert_parser = subparsers.add_parser(
         "convert", help="HTML を Markdown に変換する"
     )
-    convert_parser.add_argument("input", type=Path, help="HTML 入力ディレクトリ")
+    convert_parser.add_argument(
+        "input", type=Path, help="HTML 入力ディレクトリまたは ZIP ファイルのパス"
+    )
     convert_parser.add_argument(
         "-o",
         "--output",
@@ -70,9 +72,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     convert_parser.add_argument(
         "--zip",
-        type=Path,
-        default=None,
-        help="ZIP ファイルから変換する場合のパス",
+        action="store_true",
+        default=False,
+        help="入力を ZIP ファイルとして扱う",
     )
 
     # --- combine ---
@@ -131,9 +133,8 @@ def _run_crawl(args: argparse.Namespace) -> None:
 
 def _run_convert(args: argparse.Namespace) -> None:
     """convert サブコマンドを実行する。"""
-    if args.zip is not None:
-        zip_path: Path = args.zip
-        files = convert_zip(zip_path, args.output)
+    if args.zip:
+        files = convert_zip(args.input, args.output)
     else:
         config = ConvertConfig(input_dir=args.input, output_dir=args.output)
         files = convert_directory(config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,11 +110,10 @@ def test_cli_convert_zip(tmp_path: Path) -> None:
     main(
         [
             "convert",
-            str(tmp_path),
+            str(zip_path),
             "-o",
             str(output_dir),
             "--zip",
-            str(zip_path),
         ]
     )
 


### PR DESCRIPTION
## Summary
- `--zip` を `Path` 引数から `store_true` の bool フラグに変更
- `input` 位置引数で ZIP ファイルパスを直接指定できるように修正
- ダミー値を渡す必要がなくなり、`convert docs.zip -o out --zip` のように自然に使えるようになった

## Test plan
- [x] `tests/test_cli.py::test_cli_convert_zip` が通ること
- [x] `tests/test_cli.py::test_cli_convert` (通常変換) が壊れていないこと
- [x] `ruff check` / `pyright` がパスすること

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)