### PR TITLE
feat: HTMLファイル検索の再帰化・.htm対応・階層構造維持

### DIFF
--- a/src/notebooklm_connector/combiner.py
+++ b/src/notebooklm_connector/combiner.py
@@ -19,7 +19,10 @@ def combine(config: CombineConfig) -> Path:
     Returns:
         生成された結合ファイルのパス。
     """
-    md_files = sorted(config.input_dir.glob("*.md"))
+    md_files = sorted(
+        config.input_dir.rglob("*.md"),
+        key=lambda p: p.relative_to(config.input_dir),
+    )
 
     if not md_files:
         logger.warning("Markdown ファイルが見つかりません: %s", config.input_dir)
@@ -31,7 +34,8 @@ def combine(config: CombineConfig) -> Path:
     for md_file in md_files:
         content = md_file.read_text(encoding="utf-8").strip()
         if config.add_source_header:
-            header = f"<!-- Source: {md_file.name} -->"
+            relative = md_file.relative_to(config.input_dir)
+            header = f"<!-- Source: {relative.as_posix()} -->"
             sections.append(f"{header}\n\n{content}")
         else:
             sections.append(content)


### PR DESCRIPTION
## Summary
- `convert_directory()` を `rglob` 化し、サブディレクトリ内の `.html`/`.htm` ファイルも変換対象に
- `convert_zip()` の階層フラット化を廃止し、ZIP 内のパス構造をそのまま出力に再現
- `combine()` を `rglob` 化し、サブディレクトリ内の `.md` も結合対象に。ソースヘッダーに相対パスを使用

Closes #8

## Test plan
- [x] `test_convert_directory_recursive`: サブディレクトリ内 HTML の変換と階層維持
- [x] `test_convert_directory_htm_extension`: `.htm` 拡張子の変換
- [x] `test_convert_zip_preserves_hierarchy`: ZIP 内階層構造の維持
- [x] `test_convert_zip_htm_extension`: ZIP 内 `.htm` の変換
- [x] `test_combine_recursive`: サブディレクトリ内 MD の結合
- [x] `test_combine_source_header_relative_path`: 相対パスのソースヘッダー
- [x] 既存テスト 45 件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)