### PR TITLE
feat: ソースヘッダーをプレーンテキスト化し語数超過時にファイル分割する

### DIFF
--- a/src/notebooklm_connector/cli.py
+++ b/src/notebooklm_connector/cli.py
@@ -144,8 +144,9 @@ def _run_convert(args: argparse.Namespace) -> None:
 def _run_combine(args: argparse.Namespace) -> None:
     """combine サブコマンドを実行する。"""
     config = CombineConfig(input_dir=args.input, output_file=args.output)
-    output = combine(config)
-    print(f"結合ファイルを生成しました: {output}")
+    outputs = combine(config)
+    for output in outputs:
+        print(f"結合ファイルを生成しました: {output}")
 
 
 def _run_pipeline(args: argparse.Namespace) -> None:
@@ -175,8 +176,9 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     # Step 3: Combine
     print("=== Step 3/3: 結合 ===")
     combine_config = CombineConfig(input_dir=md_dir, output_file=combined_file)
-    output = combine(combine_config)
-    print(f"結合ファイルを生成しました: {output}")
+    outputs = combine(combine_config)
+    for output in outputs:
+        print(f"結合ファイルを生成しました: {output}")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/notebooklm_connector/combiner.py
+++ b/src/notebooklm_connector/combiner.py
@@ -10,14 +10,56 @@ logger = logging.getLogger(__name__)
 _WORD_COUNT_WARNING_THRESHOLD = 500_000
 
 
-def combine(config: CombineConfig) -> Path:
+def _split_sections(
+    sections: list[str],
+    separator: str,
+    threshold: int,
+) -> list[str]:
+    """セクションを語数閾値に基づいてチャンクに分割する。
+
+    Args:
+        sections: 結合対象のセクション一覧。
+        separator: セクション間のセパレータ。
+        threshold: 1チャンクあたりの語数上限。
+
+    Returns:
+        分割されたチャンクのリスト。
+    """
+    chunks: list[str] = []
+    current_sections: list[str] = []
+    current_word_count = 0
+
+    for section in sections:
+        section_words = len(section.split())
+        sep_words = len(separator.split()) if current_sections else 0
+        new_count = current_word_count + sep_words + section_words
+
+        if current_sections and new_count > threshold:
+            chunk = separator.join(current_sections) + "\n"
+            chunks.append(chunk)
+            current_sections = [section]
+            current_word_count = section_words
+        else:
+            current_sections.append(section)
+            current_word_count = new_count
+
+    if current_sections:
+        chunk = separator.join(current_sections) + "\n"
+        chunks.append(chunk)
+
+    return chunks
+
+
+def combine(config: CombineConfig) -> list[Path]:
     """Markdown ファイルをアルファベット順でソートし 1 ファイルに結合する。
+
+    語数が閾値を超える場合はファイルを自動分割する。
 
     Args:
         config: 結合設定。
 
     Returns:
-        生成された結合ファイルのパス。
+        生成された結合ファイルのパスのリスト。
     """
     md_files = sorted(
         config.input_dir.rglob("*.md"),
@@ -28,36 +70,49 @@ def combine(config: CombineConfig) -> Path:
         logger.warning("Markdown ファイルが見つかりません: %s", config.input_dir)
         config.output_file.parent.mkdir(parents=True, exist_ok=True)
         config.output_file.write_text("", encoding="utf-8")
-        return config.output_file
+        return [config.output_file]
 
     sections: list[str] = []
     for md_file in md_files:
         content = md_file.read_text(encoding="utf-8").strip()
         if config.add_source_header:
             relative = md_file.relative_to(config.input_dir)
-            header = f"<!-- Source: {relative.as_posix()} -->"
+            header = f"Source: {relative.as_posix()}"
             sections.append(f"{header}\n\n{content}")
         else:
             sections.append(content)
 
     combined = config.separator.join(sections) + "\n"
-
-    # 語数チェック
     word_count = len(combined.split())
-    if word_count > _WORD_COUNT_WARNING_THRESHOLD:
-        logger.warning(
-            "結合ファイルが %d 語を超えています (%d 語)。"
-            "NotebookLM の制限を超える可能性があります。",
-            _WORD_COUNT_WARNING_THRESHOLD,
-            word_count,
-        )
 
     config.output_file.parent.mkdir(parents=True, exist_ok=True)
-    config.output_file.write_text(combined, encoding="utf-8")
+
+    if word_count <= _WORD_COUNT_WARNING_THRESHOLD:
+        config.output_file.write_text(combined, encoding="utf-8")
+        logger.info(
+            "%d ファイルを結合しました: %s (%d 語)",
+            len(md_files),
+            config.output_file,
+            word_count,
+        )
+        return [config.output_file]
+
+    # 閾値超過: セクション単位で分割
+    chunks = _split_sections(sections, config.separator, _WORD_COUNT_WARNING_THRESHOLD)
+    stem = config.output_file.stem
+    suffix = config.output_file.suffix
+    parent = config.output_file.parent
+
+    output_files: list[Path] = []
+    for i, chunk in enumerate(chunks, start=1):
+        path = parent / f"{stem}-{i:03d}{suffix}"
+        path.write_text(chunk, encoding="utf-8")
+        output_files.append(path)
+
     logger.info(
-        "%d ファイルを結合しました: %s (%d 語)",
+        "%d ファイルを %d 個に分割しました (%d 語)",
         len(md_files),
-        config.output_file,
+        len(output_files),
         word_count,
     )
-    return config.output_file
+    return output_files


### PR DESCRIPTION
## Summary
- ソースヘッダーを HTMLコメント (`<!-- Source: ... -->`) からプレーンテキスト (`Source: ...`) に変更
- 500,000語超過時にセクション単位でファイルを自動分割（`output-001.md`, `output-002.md`, ...）
- `combine()` の戻り値を `Path` → `list[Path]` に変更し、CLI側も対応

Closes #10

## Test plan
- [x] 既存テスト修正（ヘッダー文字列・戻り値の型変更）
- [x] `test_combine_splits_large_output`: 閾値超過時にファイルが分割されること
- [x] `test_combine_split_file_naming`: 分割ファイルの命名が `-001` 形式であること
- [x] `test_combine_no_split_under_threshold`: 閾値以下では分割されないこと
- [x] ruff format / ruff check / pyright / pytest 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)