### PR TITLE
feat: 処理結果サマリーとレポートファイル出力

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ uv run notebooklm-connector pipeline https://example.com/docs -o output/
 
 `--max-pages` に達した場合でも、再実行すればキャッシュ済みページをスキップして未取得のページから追加クロールを継続できます。
 
+### レポート出力
+
+`--report` オプションを指定すると、処理結果のサマリーを JSON ファイルに出力できます。
+
+```bash
+uv run notebooklm-connector --report report.json pipeline https://example.com/docs -o output/
+```
+
+コンソールには各ステップのサマリーと合計が表示されます:
+
+```
+=== Step 1/3: クロール ===
+クロール: 15 ファイル (2.3 MB), 45.2 秒 → output/html
+=== Step 2/3: 変換 ===
+変換: 15 ファイル (337.6 KB), 2.2 秒 → output/md
+=== Step 3/3: 結合 ===
+結合: 1 ファイル (291.8 KB), 0.3 秒 → output/combined.md
+=== 完了 ===
+合計: 47.7 秒, 3 ステップ
+```
+
 ### 個別実行
 
 ```bash

--- a/src/notebooklm_connector/models.py
+++ b/src/notebooklm_connector/models.py
@@ -53,3 +53,22 @@ class CombineConfig:
     output_file: Path
     separator: str = "\n\n---\n\n"
     add_source_header: bool = True
+
+
+@dataclass
+class StepResult:
+    """個別ステップの処理結果。"""
+
+    step_name: str
+    file_count: int
+    total_bytes: int
+    elapsed_seconds: float
+    output_path: str
+
+
+@dataclass
+class PipelineReport:
+    """パイプライン全体の処理レポート。"""
+
+    steps: list[StepResult]
+    total_elapsed_seconds: float

--- a/src/notebooklm_connector/report.py
+++ b/src/notebooklm_connector/report.py
@@ -1,0 +1,75 @@
+"""処理結果サマリーのフォーマットとレポートファイル出力。"""
+
+import dataclasses
+import json
+from pathlib import Path
+
+from notebooklm_connector.models import PipelineReport, StepResult
+
+
+def _format_bytes(size: int) -> str:
+    """バイト数を人間が読みやすい形式に変換する。
+
+    Args:
+        size: バイト数。
+
+    Returns:
+        フォーマットされた文字列（例: "2.3 MB"）。
+    """
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    if size < 1024 * 1024 * 1024:
+        return f"{size / (1024 * 1024):.1f} MB"
+    return f"{size / (1024 * 1024 * 1024):.1f} GB"
+
+
+def format_step_summary(result: StepResult) -> str:
+    """ステップ結果を1行サマリー文字列にフォーマットする。
+
+    Args:
+        result: ステップの処理結果。
+
+    Returns:
+        サマリー文字列（例: "クロール: 15 ファイル (2.3 MB), 45.2 秒 → output/html"）。
+    """
+    size_str = _format_bytes(result.total_bytes)
+    return (
+        f"{result.step_name}: {result.file_count} ファイル"
+        f" ({size_str}), {result.elapsed_seconds:.1f} 秒"
+        f" → {result.output_path}"
+    )
+
+
+def format_pipeline_summary(report: PipelineReport) -> str:
+    """パイプライン全体のサマリー文字列を生成する。
+
+    Args:
+        report: パイプラインの処理レポート。
+
+    Returns:
+        全ステップのサマリーと合計行を含む文字列。
+    """
+    lines: list[str] = []
+    for step in report.steps:
+        lines.append(format_step_summary(step))
+    lines.append(
+        f"合計: {report.total_elapsed_seconds:.1f} 秒, {len(report.steps)} ステップ"
+    )
+    return "\n".join(lines)
+
+
+def write_report(report: PipelineReport, path: Path) -> None:
+    """レポートをJSONファイルに出力する。
+
+    Args:
+        report: パイプラインの処理レポート。
+        path: 出力先ファイルパス。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = dataclasses.asdict(report)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,92 @@
+"""report モジュールのテスト。"""
+
+import json
+from pathlib import Path
+
+from notebooklm_connector.models import PipelineReport, StepResult
+from notebooklm_connector.report import (
+    _format_bytes,
+    format_pipeline_summary,
+    format_step_summary,
+    write_report,
+)
+
+
+def test_format_bytes_b() -> None:
+    """バイト単位の表示。"""
+    assert _format_bytes(0) == "0 B"
+    assert _format_bytes(512) == "512 B"
+    assert _format_bytes(1023) == "1023 B"
+
+
+def test_format_bytes_kb() -> None:
+    """KB 単位の表示。"""
+    assert _format_bytes(1024) == "1.0 KB"
+    assert _format_bytes(2560) == "2.5 KB"
+
+
+def test_format_bytes_mb() -> None:
+    """MB 単位の表示。"""
+    assert _format_bytes(1024 * 1024) == "1.0 MB"
+    assert _format_bytes(int(2.3 * 1024 * 1024)) == "2.3 MB"
+
+
+def test_format_bytes_gb() -> None:
+    """GB 単位の表示。"""
+    assert _format_bytes(1024 * 1024 * 1024) == "1.0 GB"
+    assert _format_bytes(int(1.5 * 1024 * 1024 * 1024)) == "1.5 GB"
+
+
+def test_format_step_summary() -> None:
+    """ステップサマリーの内容検証。"""
+    result = StepResult(
+        step_name="クロール",
+        file_count=15,
+        total_bytes=int(2.3 * 1024 * 1024),
+        elapsed_seconds=45.2,
+        output_path="output/html",
+    )
+    summary = format_step_summary(result)
+    assert "クロール" in summary
+    assert "15 ファイル" in summary
+    assert "2.3 MB" in summary
+    assert "45.2 秒" in summary
+    assert "output/html" in summary
+
+
+def test_format_pipeline_summary() -> None:
+    """パイプラインサマリーの内容検証。"""
+    steps = [
+        StepResult("クロール", 15, 2 * 1024 * 1024, 45.2, "output/html"),
+        StepResult("変換", 15, 300 * 1024, 2.2, "output/md"),
+        StepResult("結合", 1, 290 * 1024, 0.3, "output/combined.md"),
+    ]
+    report = PipelineReport(steps=steps, total_elapsed_seconds=47.7)
+    summary = format_pipeline_summary(report)
+
+    assert "クロール" in summary
+    assert "変換" in summary
+    assert "結合" in summary
+    assert "47.7 秒" in summary
+    assert "3 ステップ" in summary
+
+
+def test_write_report(tmp_path: Path) -> None:
+    """JSON レポート出力の構造・値検証。"""
+    steps = [
+        StepResult("クロール", 10, 1024, 5.0, "out/html"),
+        StepResult("変換", 10, 512, 1.0, "out/md"),
+    ]
+    report = PipelineReport(steps=steps, total_elapsed_seconds=6.0)
+    report_path = tmp_path / "sub" / "report.json"
+
+    write_report(report, report_path)
+
+    assert report_path.exists()
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert data["total_elapsed_seconds"] == 6.0
+    assert len(data["steps"]) == 2
+    assert data["steps"][0]["step_name"] == "クロール"
+    assert data["steps"][0]["file_count"] == 10
+    assert data["steps"][0]["total_bytes"] == 1024
+    assert data["steps"][1]["step_name"] == "変換"


### PR DESCRIPTION
## Summary

- 各コマンド（crawl/convert/combine/pipeline）実行時にファイル数・サイズ・処理時間のサマリーをコンソールに表示
- `--report` オプションで処理結果を JSON ファイルに出力する機能を追加
- `StepResult` / `PipelineReport` データクラスと `report.py` モジュールを新規作成

## Test plan

- [x] `uv run --frozen ruff format . && uv run --frozen ruff check .` パス
- [x] `uv run --frozen pyright` 0 errors
- [x] `uv run --frozen pytest` 全 58 テストパス（新規 7 テスト含む）
- [x] 手動確認: `uv run notebooklm-connector --report report.json pipeline <url> -o output/` でサマリー表示と JSON 出力

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)