### PR TITLE
feat: report.json にクロール・変換の詳細情報を追加

### DIFF
--- a/src/notebooklm_connector/models.py
+++ b/src/notebooklm_connector/models.py
@@ -66,6 +66,9 @@ class StepResult:
     total_bytes: int
     elapsed_seconds: float
     output_path: str
+    skipped_count: int = 0
+    downloaded_count: int = 0
+    failure_count: int = 0
 
 
 @dataclass
@@ -74,3 +77,5 @@ class PipelineReport:
 
     steps: list[StepResult]
     total_elapsed_seconds: float
+    crawl_failures: list[str] = field(default_factory=lambda: [])
+    convert_failures: list[str] = field(default_factory=lambda: [])


### PR DESCRIPTION
Closes #22

## Summary

- `StepResult` に `skipped_count` / `downloaded_count` / `failure_count` フィールドを追加
- `PipelineReport` に `crawl_failures` / `convert_failures` リストを追加
- `crawler`: キャッシュヒット数・ダウンロード数・失敗URLを集計して返却するよう変更
- `converter`: 変換失敗ファイルを収集して返却（`OSError` / `PermissionError` / `UnicodeDecodeError` をキャッチ）
- `cli`: `output_path` をUnix形式（スラッシュ区切り）に統一（Windows環境でのバックスラッシュ問題を修正）

## Test plan

- [x] `uv run --frozen ruff format --check .` がパスすること
- [x] `uv run --frozen ruff check .` がパスすること
- [x] `uv run --frozen pyright` がパスすること
- [x] `uv run --frozen pytest` で 68 テストがすべてパスすること
- [x] `report.json` に `crawl_failures` / `convert_failures` / `skipped_count` / `downloaded_count` / `failure_count` が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)