### PR TITLE
feat: 失敗したファイルのみ再実行する --retry-from-report オプションを追加 (#23)

### DIFF
--- a/src/notebooklm_connector/report.py
+++ b/src/notebooklm_connector/report.py
@@ -60,6 +60,31 @@ def format_pipeline_summary(report: PipelineReport) -> str:
     return "\n".join(lines)
 
 
+def read_report(path: Path) -> PipelineReport:
+    """JSON ファイルからレポートを読み込む。
+
+    Args:
+        path: 読み込むレポートファイルのパス。
+
+    Returns:
+        PipelineReport インスタンス。
+
+    Raises:
+        OSError: ファイルの読み取りに失敗した場合。
+        json.JSONDecodeError: JSON のパースに失敗した場合。
+        KeyError: 必須フィールドが存在しない場合。
+    """
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    steps = [StepResult(**s) for s in data["steps"]]
+    return PipelineReport(
+        steps=steps,
+        total_elapsed_seconds=data["total_elapsed_seconds"],
+        crawl_failures=data.get("crawl_failures", []),
+        convert_failures=data.get("convert_failures", []),
+    )
+
+
 def write_report(report: PipelineReport, path: Path) -> None:
     """レポートをJSONファイルに出力する。
 


### PR DESCRIPTION
## Summary

- `report.py` に `read_report()` を追加し、前回の `report.json` から `PipelineReport` を復元できるようにする
- `crawler.py` に `crawl_urls()` を追加し、BFS なしで指定 URL リストのみをフェッチする（失敗 URL の再クロール用）
- `converter.py` に `convert_failed_files()` を追加し、指定ファイルパスのみを再変換する（失敗ファイルの再変換用）
- `cli.py` の `crawl` / `convert` / `pipeline` サブコマンドに `--retry-from-report <REPORT_JSON>` オプションを追加
  - `crawl --retry-from-report`: 前回の `crawl_failures` のみ再クロール
  - `convert --retry-from-report`: 前回の `convert_failures` のみ再変換
  - `pipeline --retry-from-report`: `crawl_failures` を再クロールし、`convert_failures` + 新規クロール分を再変換後、`md_dir` 全体を再結合

## Usage

```bash
# 通常パイプライン実行 → report.json 生成
uv run notebooklm-connector pipeline https://example.com/docs/ -o output/ --report output/report.json

# 失敗分のみ再実行
uv run notebooklm-connector pipeline https://example.com/docs/ -o output/ --retry-from-report output/report.json --report output/report2.json
```

## Test plan

- [x] `ruff format .` — 3 ファイル整形
- [x] `ruff check .` — All checks passed
- [x] `pyright` — 0 errors, 0 warnings
- [x] `pytest` — 85 tests passed (新規追加: 13 テスト)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)