### PR TITLE
feat: 実行コマンドと結合ファイル毎の語句数をreport.jsonに追加

### DIFF
--- a/src/notebooklm_connector/models.py
+++ b/src/notebooklm_connector/models.py
@@ -69,6 +69,7 @@ class StepResult:
     skipped_count: int = 0
     downloaded_count: int = 0
     failure_count: int = 0
+    output_word_counts: dict[str, int] = field(default_factory=lambda: {})
 
 
 @dataclass
@@ -79,3 +80,4 @@ class PipelineReport:
     total_elapsed_seconds: float
     crawl_failures: list[str] = field(default_factory=lambda: [])
     convert_failures: list[str] = field(default_factory=lambda: [])
+    command: list[str] = field(default_factory=lambda: [])

--- a/src/notebooklm_connector/report.py
+++ b/src/notebooklm_connector/report.py
@@ -82,6 +82,7 @@ def read_report(path: Path) -> PipelineReport:
         total_elapsed_seconds=data["total_elapsed_seconds"],
         crawl_failures=data.get("crawl_failures", []),
         convert_failures=data.get("convert_failures", []),
+        command=data.get("command", []),
     )
 
 


### PR DESCRIPTION
## Summary

- `PipelineReport` に `command: list[str]` フィールドを追加し、再実行に使えるよう実行されたコマンドを記録
- `StepResult` に `output_word_counts: dict[str, int]` フィールドを追加し、結合ステップで各出力ファイルの語句数を記録
- `combine()` の戻り値を `tuple[list[Path], dict[str, int]]` に変更し、語句数も返すようにした
- 旧フォーマットの `report.json` との後方互換性を維持（`command` / `output_word_counts` なしの既存ファイルも読み込み可能）

## report.json の出力例

```json
{
  "command": ["notebooklm-connector", "pipeline", "https://example.com/", "-o", "output/example"],
  "steps": [
    { "step_name": "クロール", ... },
    { "step_name": "変換", ... },
    {
      "step_name": "結合",
      "output_word_counts": {
        "output/example/combined-001.md": 498234,
        "output/example/combined-002.md": 312567
      },
      ...
    }
  ],
  ...
}
```

Closes #27

## Test plan

- [x] `test_combiner.py` の既存テストを新しい戻り値に対応
- [x] `test_report.py` に `command` / `output_word_counts` のシリアライズ・デシリアライズテストを追加
- [x] `test_cli.py` に `command` と `output_word_counts` がレポートに含まれることのテストを追加
- [x] 旧フォーマットからの後方互換読み込みテストを追加
- [x] 93件全テストパス / ruff / pyright 全チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)