### PR TITLE
docs: 開発コマンドから--frozenを削除しCI専用に変更

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -20,7 +20,7 @@
     - 禁止事項: 関数内でのインポート: インポート文は必ずファイルの先頭に記述すること
 
 3. テスト要件
-    - フレームワーク: `uv run --frozen pytest` を利用すること
+    - フレームワーク: `uv run pytest` を利用すること
     - 非同期テスト: asyncio ではなく anyio を使用すること
     - `Test` プリフィックスをつけたクラスは利用せず関数を利用すること
     - カバレッジ: エッジケースやエラー系もテストすること
@@ -50,9 +50,9 @@
 ## コードフォーマッタ
 
 1. Ruff
-    - フォーマット: `uv run --frozen ruff format .`
-    - チェック: `uv run --frozen ruff check .`
-    - 修正: `uv run --frozen ruff check . --fix`
+    - フォーマット: `uv run ruff format .`
+    - チェック: `uv run ruff check .`
+    - 修正: `uv run ruff check . --fix`
     - 重要事項:
         - 1行の長さ (88文字)
         - インポートのソーティング (I001)
@@ -63,7 +63,7 @@
         - インポート: 可能な限り1行にまとめること
 
 2. 型チェック
-    - ツール: `uv run --frozen pyright`
+    - ツール: `uv run pyright`
     - 要件:
         - 文字列に対する型絞り込み (Type narrowing) を適切に行うこと
         - チェックがパスしていれば、バージョンに関する警告は無視してもよい

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
     - 禁止事項: 関数内でのインポート: インポート文は必ずファイルの先頭に記述すること
 
 3. テスト要件
-    - フレームワーク: `uv run --frozen pytest` を利用すること
+    - フレームワーク: `uv run pytest` を利用すること
     - 非同期テスト: asyncio ではなく anyio を使用すること
     - `Test` プリフィックスをつけたクラスは利用せず関数を利用すること
     - カバレッジ: エッジケースやエラー系もテストすること
@@ -50,9 +50,9 @@
 ## コードフォーマッタ
 
 1. Ruff
-    - フォーマット: `uv run --frozen ruff format .`
-    - チェック: `uv run --frozen ruff check .`
-    - 修正: `uv run --frozen ruff check . --fix`
+    - フォーマット: `uv run ruff format .`
+    - チェック: `uv run ruff check .`
+    - 修正: `uv run ruff check . --fix`
     - 重要事項:
         - 1行の長さ (88文字)
         - インポートのソーティング (I001)
@@ -63,7 +63,7 @@
         - インポート: 可能な限り1行にまとめること
 
 2. 型チェック
-    - ツール: `uv run --frozen pyright`
+    - ツール: `uv run pyright`
     - 要件:
         - 文字列に対する型絞り込み (Type narrowing) を適切に行うこと
         - チェックがパスしていれば、バージョンに関する警告は無視してもよい

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ uv run pre-commit install
 ### 開発用ツール
 
 - **Lint/Format**: Ruff
-    - `uv run --frozen ruff check .` (Lint)
-    - `uv run --frozen ruff format .` (Format)
+    - `uv run ruff check .` (Lint)
+    - `uv run ruff format .` (Format)
 - **型チェック**: Pyright
-    - `uv run --frozen pyright`
+    - `uv run pyright`
 - **テスト**: pytest
-    - `uv run --frozen pytest`
+    - `uv run pytest`


### PR DESCRIPTION
## Summary

- `CLAUDE.md`、`AGENT.md`、`README.md` の開発コマンドから `--frozen` フラグを削除
- `--frozen` はロックファイルを厳密に検証するCIに適したフラグであり、開発時には不要
- `.github/workflows/ci.yml` は変更なし（CI では引き続き `--frozen` を維持）

Closes #31

## Test plan

- [x] CI（GitHub Actions）が引き続き `--frozen` で動作することを確認
- [x] 開発環境で `uv run ruff format .`、`uv run ruff check .`、`uv run pyright`、`uv run pytest` が問題なく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)