### PR TITLE
refactor: CLI/crawler/converterの保守性改善

### DIFF
--- a/src/notebooklm_connector/report.py
+++ b/src/notebooklm_connector/report.py
@@ -7,6 +7,46 @@ from pathlib import Path
 from notebooklm_connector.models import PipelineReport, StepResult
 
 
+def build_step_result(
+    step_name: str,
+    files: list[Path],
+    output_path: str,
+    elapsed_seconds: float | None = None,
+    skipped_count: int = 0,
+    downloaded_count: int = 0,
+    failure_count: int = 0,
+    output_word_counts: dict[str, int] | None = None,
+) -> StepResult:
+    """ファイル群から StepResult を構築する。
+
+    Args:
+        step_name: ステップ名。
+        files: 出力ファイル一覧。
+        output_path: 出力先パス文字列。
+        elapsed_seconds: 経過時間（秒）。None の場合は 0.0。
+        skipped_count: キャッシュヒット数。
+        downloaded_count: ダウンロード数。
+        failure_count: 失敗件数。
+        output_word_counts: 結合出力ファイルごとの語数。
+
+    Returns:
+        集計済み StepResult。
+    """
+    total_bytes = sum(path.stat().st_size for path in files if path.exists())
+    elapsed = 0.0 if elapsed_seconds is None else elapsed_seconds
+    return StepResult(
+        step_name=step_name,
+        file_count=len(files),
+        total_bytes=total_bytes,
+        elapsed_seconds=round(elapsed, 1),
+        output_path=output_path.replace("\\", "/"),
+        skipped_count=skipped_count,
+        downloaded_count=downloaded_count,
+        failure_count=failure_count,
+        output_word_counts={} if output_word_counts is None else output_word_counts,
+    )
+
+
 def _format_bytes(size: int) -> str:
     """バイト数を人間が読みやすい形式に変換する。
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,6 +8,7 @@ import pytest
 from notebooklm_connector.models import PipelineReport, StepResult
 from notebooklm_connector.report import (
     _format_bytes,
+    build_step_result,
     format_pipeline_summary,
     format_step_summary,
     read_report,
@@ -55,6 +56,24 @@ def test_format_step_summary() -> None:
     assert "2.3 MB" in summary
     assert "45.2 秒" in summary
     assert "output/html" in summary
+
+
+def test_build_step_result_normalizes_path_and_size(tmp_path: Path) -> None:
+    """StepResult 生成時にサイズ集計とパス正規化が行われること。"""
+    output_file = tmp_path / "file.md"
+    output_file.write_text("hello", encoding="utf-8")
+
+    result = build_step_result(
+        step_name="変換",
+        files=[output_file],
+        output_path="out\\md",
+        elapsed_seconds=1.234,
+    )
+
+    assert result.file_count == 1
+    assert result.total_bytes == 5
+    assert result.output_path == "out/md"
+    assert result.elapsed_seconds == 1.2
 
 
 def test_format_pipeline_summary() -> None:


### PR DESCRIPTION
## 概要
- StepResult 生成処理を report 層に集約
- CLI の処理フローを関数分割し、型安全に整理
- crawler のクライアント生成と集計処理を共通化
- converter の変換結果集計ロジックを共通化
- report の回帰テストを追加

## 変更ファイル
- src/notebooklm_connector/report.py
- tests/test_report.py
- src/notebooklm_connector/cli.py
- src/notebooklm_connector/crawler.py
- src/notebooklm_connector/converter.py

## 動作確認
- uv run ruff check .
- uv run pyright
- uv run pytest -q
  - 94 passed

Closes #37